### PR TITLE
Sleep2

### DIFF
--- a/src/esp32-wordclock/ConfigManager.cpp
+++ b/src/esp32-wordclock/ConfigManager.cpp
@@ -254,6 +254,7 @@ void ConfigManager::setup() {
             Serial.println(WiFi.localIP());
 
             WiFi.mode(WIFI_STA);
+            WiFi.setSleep(true);
             startApi();
             return;
         }

--- a/src/esp32-wordclock/display.cpp
+++ b/src/esp32-wordclock/display.cpp
@@ -6,7 +6,7 @@
 
 const int DATA_PIN = 13;
 const int MATRIXLAYOUT = 1;
-const int ORIENTATION = 0;
+const int ORIENTATION = 1;
 
 const char matrixZiffernblattLayout1[8][8] = 
 {

--- a/src/esp32-wordclock/esp32-wordclock.ino
+++ b/src/esp32-wordclock/esp32-wordclock.ino
@@ -174,131 +174,147 @@ void setzeFarben()
 
 void loop()
 {
+  // Always do...
   configManager.loop();
-
   checkConfig(false);
   checkWifi(false);
-if (countdown > 0)
-{
-  countdown--;
-}
-else
-{
-  if (countdown2 > 0)
+
+  // Periodically
+  // a) Flash LEDs every ~ 10*countdown milliseconds
+  // b) Update time every ~ 10*countdown*countdown2 milliseconds
+  if (countdown > 0)
   {
-    countdown2--;
-    bearbeiteListe(3);
+    countdown--;
   }
   else
   {
-    Serial.println();
-    Serial.print("Updating time...");
-    getLocalTime(&timeinfo);
-    Serial.print("Done");
+    // Countdown1 is zero
 
-    uint8_t internalHour = timeinfo.tm_hour;
-    uint8_t internalMinute = timeinfo.tm_min;
-    uint8_t tempHour = internalHour % 12;
-    uint8_t tempMinute = (internalMinute + 2) % 60 / 5;
-
-    if (internalMinute > 32)
+    // Reload
+    countdown = 1000;
+    
+    if (countdown2 > 0)
     {
-      tempHour = (tempHour + 1) % 12;
-    }
-
-    Serial.println();
-    Serial.print("Current time: ");
-    Serial.print(internalHour);
-    Serial.print(":");
-    Serial.print(internalMinute);
-    Serial.print(":");
-    Serial.print(timeinfo.tm_sec);
-
-    if (tempHour != letzteStunde or tempMinute != letzteMinute)
-    {
-      Serial.println();
-      Serial.print("Stelle Uhrzeit um von Stunde ");
-      Serial.print(letzteStunde);
-      Serial.print(" auf ");
-      Serial.print(tempHour);
-      Serial.print(" und Minute ");
-      Serial.print(letzteMinute);
-      Serial.print(" auf ");
-      Serial.print(tempMinute);
-      Serial.println();
-      Serial.print("In Worten: its ");
-      Serial.print(wordsMinute[tempMinute]);
-      Serial.print(" (");
-      Serial.print(tempMinute);
-      Serial.print(") ");
-      Serial.print(wordsHour[tempHour]);
-      Serial.print(" (");
-      Serial.print(tempHour);
-      Serial.print(") ");
-
-      clearLists();
-
-      if (letzteStunde != -1) {
-        reiheWortItsInListe(0);  //kein Ausblenden wenn vorher keine valide Zeit angezeigt wurde
-      }
-      reiheWortItsInListe(1);
-      reiheWortItsInListe(2);
-      reiheDummiesInListe(3, 2);
-
-      if (letzteMinute > 0)
-      {
-        reiheMinutenInListe(letzteMinute, 0, WORDLAYOUT);
-        reihePastOderToInListe(letzteMinute, 0, WORDLAYOUT);
-      }
-
-      if (tempMinute > 0)
-      {
-        reiheMinutenInListe(tempMinute, 1, WORDLAYOUT);
-        reiheMinutenInListe(tempMinute, 2, WORDLAYOUT);
-        reiheDummiesInListe(3, 2);
-        reihePastOderToInListe(tempMinute, 1, WORDLAYOUT);
-        reihePastOderToInListe(tempMinute, 2, WORDLAYOUT);
-        reiheDummiesInListe(3, 2);
-      }
-
-      if (letzteStunde != -1)
-      {
-        reiheStundenInListe(letzteStunde, 0, WORDLAYOUT);
-      }
-
-      if (tempHour != -1)
-      {
-        reiheStundenInListe(tempHour, 1, WORDLAYOUT);
-        reiheStundenInListe(tempHour, 2, WORDLAYOUT);
-        reiheDummiesInListe(3, 2);
-      }
-
-      if (letzteMinute == 0)
-      {
-        reiheWortOclockInListe(0, WORDLAYOUT);
-      }
-
-      if (tempMinute == 0)
-      {
-        reiheWortOclockInListe(1, WORDLAYOUT);
-        reiheWortOclockInListe(2, WORDLAYOUT);
-      }
-
-      bearbeiteListe(2);
-      letzteStunde = tempHour;
-      letzteMinute = tempMinute;
+      // Countdown2 is not zero --> flash LEDs
+      Serial.println("Flash LEDs");
+      countdown2--;
+      bearbeiteListe(3);
     }
     else
     {
-      Serial.println("Keine Veränderung der Zeitanzeige");
-      bearbeiteListe(3);
-    }
+      // Countdown2 is zero, too --> Update time
 
-    Serial.println("--------------");
-    countdown2 = 10;
+      // Reload
+      countdown2 = 10;
+      
+      Serial.println();
+      Serial.print("Updating time...");
+      getLocalTime(&timeinfo);
+      Serial.print("Done");
+  
+      uint8_t internalHour = timeinfo.tm_hour;
+      uint8_t internalMinute = timeinfo.tm_min;
+      uint8_t tempHour = internalHour % 12;
+      uint8_t tempMinute = (internalMinute + 2) % 60 / 5;
+  
+      if (internalMinute > 32)
+      {
+        tempHour = (tempHour + 1) % 12;
+      }
+  
+      Serial.println();
+      Serial.print("Current time: ");
+      Serial.print(internalHour);
+      Serial.print(":");
+      Serial.print(internalMinute);
+      Serial.print(":");
+      Serial.print(timeinfo.tm_sec);
+  
+      if (tempHour != letzteStunde or tempMinute != letzteMinute)
+      {
+        Serial.println();
+        Serial.print("Stelle Uhrzeit um von Stunde ");
+        Serial.print(letzteStunde);
+        Serial.print(" auf ");
+        Serial.print(tempHour);
+        Serial.print(" und Minute ");
+        Serial.print(letzteMinute);
+        Serial.print(" auf ");
+        Serial.print(tempMinute);
+        Serial.println();
+        Serial.print("In Worten: its ");
+        Serial.print(wordsMinute[tempMinute]);
+        Serial.print(" (");
+        Serial.print(tempMinute);
+        Serial.print(") ");
+        Serial.print(wordsHour[tempHour]);
+        Serial.print(" (");
+        Serial.print(tempHour);
+        Serial.print(") ");
+  
+        clearLists();
+  
+        if (letzteStunde != -1) {
+          reiheWortItsInListe(0);  //kein Ausblenden wenn vorher keine valide Zeit angezeigt wurde
+        }
+        reiheWortItsInListe(1);
+        reiheWortItsInListe(2);
+        reiheDummiesInListe(3, 2);
+  
+        if (letzteMinute > 0)
+        {
+          reiheMinutenInListe(letzteMinute, 0, WORDLAYOUT);
+          reihePastOderToInListe(letzteMinute, 0, WORDLAYOUT);
+        }
+  
+        if (tempMinute > 0)
+        {
+          reiheMinutenInListe(tempMinute, 1, WORDLAYOUT);
+          reiheMinutenInListe(tempMinute, 2, WORDLAYOUT);
+          reiheDummiesInListe(3, 2);
+          reihePastOderToInListe(tempMinute, 1, WORDLAYOUT);
+          reihePastOderToInListe(tempMinute, 2, WORDLAYOUT);
+          reiheDummiesInListe(3, 2);
+        }
+  
+        if (letzteStunde != -1)
+        {
+          reiheStundenInListe(letzteStunde, 0, WORDLAYOUT);
+        }
+  
+        if (tempHour != -1)
+        {
+          reiheStundenInListe(tempHour, 1, WORDLAYOUT);
+          reiheStundenInListe(tempHour, 2, WORDLAYOUT);
+          reiheDummiesInListe(3, 2);
+        }
+  
+        if (letzteMinute == 0)
+        {
+          reiheWortOclockInListe(0, WORDLAYOUT);
+        }
+  
+        if (tempMinute == 0)
+        {
+          reiheWortOclockInListe(1, WORDLAYOUT);
+          reiheWortOclockInListe(2, WORDLAYOUT);
+        }
+  
+        bearbeiteListe(2);
+        letzteStunde = tempHour;
+        letzteMinute = tempMinute;
+      }
+      else
+      {
+        Serial.println("Keine Veränderung der Zeitanzeige");
+        bearbeiteListe(3);
+      }
+  
+      Serial.println("--------------");
+      Serial.println();
+    }
   }
-  countdown = 65000;
-}
+  delay(10);
   // Sleep for 5 seconds
 //  esp_sleep_enable_timer_wakeup(5e6);
 //  esp_light_sleep_start();

--- a/src/esp32-wordclock/esp32-wordclock.ino
+++ b/src/esp32-wordclock/esp32-wordclock.ino
@@ -7,7 +7,7 @@
 
 
 
-const int WORDLAYOUT = 2;
+const int WORDLAYOUT = 1;
 
 
 int aktuelleMinute;
@@ -176,8 +176,6 @@ void setzeFarben()
   setzeFarbe(validConfig.c1);
 }
 
-
-
 void loop()
 {
   // Always do...
@@ -186,8 +184,8 @@ void loop()
   checkWifi(false);
 
   // Periodically
-  // a) Flash LEDs every ~ 10*countdown milliseconds
-  // b) Update time every ~ 10*countdown*countdown2 milliseconds
+  // a) Flash LEDs every ~ 1*countdown milliseconds
+  // b) Update time every ~ 1*countdown*countdown2 milliseconds
   if (countdown > 0)
   {
     countdown--;
@@ -197,7 +195,7 @@ void loop()
     // Countdown1 is zero
 
     // Reload
-    countdown = 1000;
+    countdown = 10000;
     
     if (countdown2 > 0)
     {
@@ -212,62 +210,17 @@ void loop()
         
       // Reload
       countdown2 = 10;
-
-      Serial.println();
-      Serial.print("Stelle Uhrzeit um von Stunde ");
-      Serial.print(letzteStunde);
-      Serial.print(" auf ");
-      Serial.print(tempHour);
-      Serial.print(" und Minute ");
-      Serial.print(letzteMinute);
-      Serial.print(" auf ");
-      Serial.print(tempMinute);
-      Serial.println();
-      Serial.print("In Worten: its ");
-      Serial.print(wordsMinute[tempMinute]);
-      Serial.print(" (");
-      Serial.print(tempMinute);
-      Serial.print(") ");
-      Serial.print(wordsHour[tempHour]);
-      Serial.print(" (");
-      Serial.print(tempHour);
-      Serial.print(") ");
-
-      clearLists(-1);
-
-      if (letzteStunde != -1) {
-        reiheWortItsInListe(0);  //kein Ausblenden wenn vorher keine valide Zeit angezeigt wurde
-      }
-      reiheWortItsInListe(1);
-      reiheWortItsInListe(2);
-      reiheDummiesInListe(3, 2);
-
-      if (letzteMinute > 0)
-      {
-        reiheMinutenInListe(letzteMinute, 0, WORDLAYOUT);
-        reihePastOderToInListe(letzteMinute, 0, WORDLAYOUT);
-      }
-
-      if (tempMinute > 0)
-      {
-        reiheMinutenInListe(tempMinute, 1, WORDLAYOUT);
-        reiheMinutenInListe(tempMinute, 2, WORDLAYOUT);
-        reiheDummiesInListe(3, 2);
-        reihePastOderToInListe(tempMinute, 1, WORDLAYOUT);
-        reihePastOderToInListe(tempMinute, 2, WORDLAYOUT);
-        reiheDummiesInListe(3, 2);
-      }
-
+      
       Serial.println();
       Serial.print("Updating time...");
       getLocalTime(&timeinfo);
       Serial.print("Done");
-  
-      uint8_t internalHour = timeinfo.tm_hour;
+
+      uint8_t internalHour   = timeinfo.tm_hour;
       uint8_t internalMinute = timeinfo.tm_min;
-      uint8_t tempHour = internalHour % 12;
-      uint8_t tempMinute = (internalMinute + 2) % 60 / 5;
-  
+      uint8_t tempHour       = internalHour % 12;
+      uint8_t tempMinute     = (internalMinute + 2) % 60 / 5;
+      
       if (internalMinute > 32)
       {
         tempHour = (tempHour + 1) % 12;
@@ -280,7 +233,7 @@ void loop()
       Serial.print(internalMinute);
       Serial.print(":");
       Serial.print(timeinfo.tm_sec);
-  
+      
       if (tempHour != letzteStunde or tempMinute != letzteMinute)
       {
         Serial.println();
@@ -303,7 +256,7 @@ void loop()
         Serial.print(tempHour);
         Serial.print(") ");
   
-        clearLists();
+        clearLists(-1);
   
         if (letzteStunde != -1) {
           reiheWortItsInListe(0);  //kein Ausblenden wenn vorher keine valide Zeit angezeigt wurde
@@ -311,13 +264,13 @@ void loop()
         reiheWortItsInListe(1);
         reiheWortItsInListe(2);
         reiheDummiesInListe(3, 2);
-  
+        
         if (letzteMinute > 0)
         {
           reiheMinutenInListe(letzteMinute, 0, WORDLAYOUT);
           reihePastOderToInListe(letzteMinute, 0, WORDLAYOUT);
         }
-  
+
         if (tempMinute > 0)
         {
           reiheMinutenInListe(tempMinute, 1, WORDLAYOUT);
@@ -327,7 +280,8 @@ void loop()
           reihePastOderToInListe(tempMinute, 2, WORDLAYOUT);
           reiheDummiesInListe(3, 2);
         }
-  
+        
+        
         if (letzteStunde != -1)
         {
           reiheStundenInListe(letzteStunde, 0, WORDLAYOUT);
@@ -339,7 +293,7 @@ void loop()
           reiheStundenInListe(tempHour, 2, WORDLAYOUT);
           reiheDummiesInListe(3, 2);
         }
-  
+        
         if (letzteMinute == 0)
         {
           reiheWortOclockInListe(0, WORDLAYOUT);
@@ -365,7 +319,7 @@ void loop()
       Serial.println();
     }
   }
-  delay(10);
+  delay(1);
   // Sleep for 5 seconds
 //  esp_sleep_enable_timer_wakeup(5e6);
 //  esp_light_sleep_start();


### PR DESCRIPTION
Sleep mode for Wifi and small delay main loop added. Should reduce the power consumtion significantly.

Power consumption can still be improved but this would make a change in behaviour neccessary. The clock should not be constantly available via Wifi but only ~5 Minutes after power up. Then the Wifi can be completely turned off and only switched on to synchronize the time via NTP server.

Wifi Off -> Deep sleep possible. Deep sleep would only be interrupted for scheduled events:
 - When is the next animation going to be displayed?
 - When does the displayed time need to be updated?
--> Calculate sleep timeout and wake up at the right time, then go to deep sleep again.